### PR TITLE
Overwrite the aws config instead of appending

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ config="${awsDir}/config"
 credentials="${awsDir}/credentials"
 
 mkdir -p "${awsDir}"
-echo -e "[profile default]\noutput = json" >>"$config"
+echo -e "[profile default]\noutput = json" >"$config"
 
 # Attempt to get aws credentials via tokendito
 max_attempts=10


### PR DESCRIPTION
We have a workflow in which we need to run this action multiple times to login to multiple aws accounts. On the second run, appending another default profile will cause an error.

Overwriting the aws config instead of just appending to it.